### PR TITLE
Fix resourcePath and resourcePathName when uri contains parameters

### DIFF
--- a/lib/raml/node/abstract_resource.rb
+++ b/lib/raml/node/abstract_resource.rb
@@ -77,6 +77,15 @@ module Raml
       @parent.resource_path + self.name
     end
 
+
+    # Returns the last non regex resource name
+    # @return [String] the last non request resource name
+    def resource_path_name
+      resource_path.split('/').reverse.detect do |pathPart|
+        !pathPart.match(/[{}]/)
+      end || ""
+    end
+
     private
     
     def validate_parent
@@ -153,7 +162,7 @@ module Raml
     def instantiate_resource_type
       reserved_params = {
         'resourcePath'     => resource_path,
-        'resourcePathName' => resource_path.split('/')[-1]
+        'resourcePathName' => resource_path_name
       }
       if ResourceTypeReference === type
         resource_type_declarations[type.name].instantiate type.parameters.merge reserved_params

--- a/lib/raml/node/method.rb
+++ b/lib/raml/node/method.rb
@@ -93,7 +93,7 @@ module Raml
     def instantiate_trait(trait)
       reserved_params = {
         'resourcePath'     => @parent.resource_path,
-        'resourcePathName' => @parent.resource_path.split('/')[-1],
+        'resourcePathName' => @parent.resource_path_name,
         'methodName'       => self.name
       }
       if TraitReference === trait

--- a/test/raml/resource_spec.rb
+++ b/test/raml/resource_spec.rb
@@ -320,9 +320,10 @@ describe Raml::Resource do
       'get'  => {'description' => 'method description'},
       'post' => {},
       '/foo' => {},
-      '/bar' => {}
+      '/bar/{id}' => {}
     } }
     let(:resource) { Raml::Resource.new('/foo', resource_data, root)  }
+    let(:resource_with_parameter) { Raml::Resource.new('/bar/{id}', resource_data, root)  }
     context 'when it has a resource type' do
       it 'merges the resource type to the resource' do
         resource.type.should be_a Raml::ResourceType
@@ -337,6 +338,12 @@ describe Raml::Resource do
         resource.apply_resource_type
         resource.methods['get'].description.should  eq 'method description'
         resource.methods['get'].display_name.should eq 'resource type displayName'
+        resource.resource_path.should eq '/foo'
+        resource.resource_path_name.should eq 'foo'
+      end
+      it 'sets the resource path name stripping out uri parameters' do
+        resource_with_parameter.apply_resource_type
+        resource_with_parameter.resource_path_name.should eq 'bar'
       end
     end
     context 'when it has nested resources' do


### PR DESCRIPTION
I run into this a while ago. Based on the [code](https://github.com/raml-org/raml-js-parser/blob/de00cd5cc9aecf6d9fd039a7ac1dec5eaf156376/src/traits.coffee#L158-L163) in raml-js-parser here, the resourcePathName should strip out the uri parameters.