### PR TITLE
Add singleton file_path method to contents resolved by include

### DIFF
--- a/lib/raml/node/template.rb
+++ b/lib/raml/node/template.rb
@@ -16,7 +16,7 @@ module Raml
 
     def clone_data
       # ugly but effective
-      Marshal.load Marshal.dump @value
+      Marshal.load Marshal.dump @value.dup
     end
 
     def interpolate_params(value, params)

--- a/lib/raml/parser.rb
+++ b/lib/raml/parser.rb
@@ -35,7 +35,9 @@ module Raml
           
           if val.is_a? Raml::Parser::Include
             child_wd = expand_includes_working_dir cwd, val.path
+            path = val.path
             val      = val.content cwd
+            val.define_singleton_method(:file_path) { child_wd + "/" + path.split("/").last }
           end
           
           expand_includes val, child_wd

--- a/test/raml/parser_spec.rb
+++ b/test/raml/parser_spec.rb
@@ -36,7 +36,13 @@ describe Raml::Parser do
         root.schemas['Test'      ].value.should eq 'test_schema'
         root.schemas['File'      ].value.should eq 'file_schema'
       end
-      
+
+      it "inserts singleton method to read the file_path" do
+        file = File.new 'fixtures/include_1.raml'
+        root = Raml::Parser.parse file.read, 'fixtures'
+        root.schemas['FileUpdate'].value.file_path.should eq 'fixtures/schemas/filesystem/fileupdate.json'
+      end
+
       context 'when the included file is not redable' do
         it do
           expect { Raml::Parser.parse('- !include does_not_exit') }.to raise_error Raml::CantIncludeFile


### PR DESCRIPTION
I have my RAML splitted into multiple files and my schemas also using the [$ref](http://json-schema.org/example2.html) to be able to re-use and share JSON schemas across different endpoints. An example of these would be:
```
{
  "$schema": "http://json-schema.org/draft-04/schema",
  "type": "array",
  "title": "Devices",
  "description": "List of devices",
  "maxItems": 1,
  "items": {
    "$ref": "./model.json"
  }
}
```

The relative referenced file "model.json" is currently used in other schemas. This is something that I think happens too with the raml-js-parser. The issue comes up when the RAML parser resolves the !include reference to the schema. The "relativeness" of the internal "./model.json" path is lost when this happens, because there is no way to know where the schema was living before it was read.

This topic has a few threads open, but I haven't been able to yet find a clear solution for the implementation.
* http://forums.raml.org/t/how-do-i-reference-nested-sub-schemas-from-raml/583
* http://forums.raml.org/t/how-do-you-reference-another-schema-from-a-schema/485

This is definitely not ideal, but the solution I have found, is to add an instance method to the eigen class of the value that holds the schema. This way the location from where it was included can be recovered.

If you have any other ideas on how to approach this I'm more than happy to give it a shot.  