### PR TITLE
Generic media type */* should be valid

### DIFF
--- a/lib/raml/node/body.rb
+++ b/lib/raml/node/body.rb
@@ -60,7 +60,11 @@ module Raml
     private
 
     def validate_name
-      raise InvalidMediaType, 'body media type is invalid' unless media_type =~ Body::MEDIA_TYPE_RE
+      raise InvalidMediaType, 'body media type is invalid' unless valid_media_type?
+    end
+
+    def valid_media_type?
+       media_type =~ Body::MEDIA_TYPE_RE || media_type == '*/*'
     end
 
     def parse_form_parameters(value)

--- a/test/raml/body_spec.rb
+++ b/test/raml/body_spec.rb
@@ -35,6 +35,12 @@ describe Raml::Body do
         expect( subject.media_type ).to eq media_type
       end
     end
+    context 'when the media type is "*/*"' do
+      let(:media_type) { '*/*' }
+      it 'inits the body with the media_type' do
+        expect( subject.media_type ).to eq media_type
+      end
+    end
     context 'when the media type is invalid' do
       let(:media_type) { 'foo' }
       it { expect { subject }.to raise_error Raml::InvalidMediaType }


### PR DESCRIPTION
I think it would be great to allow a generic media type for bodies. As it says in RAML spec:

`For APIs without a priori knowledge of the response types for their responses, "*/*" MAY be used to indicate that responses that do not matching other defined data types MUST be accepted. Processing applications MUST match the most descriptive media type first if "*/*" is used.`
https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#responses

I didn't want to alter the regular expression because then `"application/*"` could become a valid media type and I don't think it should be.

Thanks for taking the time to build the ruby raml parser :)