### PR TITLE
bump up json-schema version to latest

### DIFF
--- a/raml_ruby.gemspec
+++ b/raml_ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activesupport', '~> 4.1'
-  spec.add_dependency 'json-schema'  , '~> 2.4.1'
+  spec.add_dependency 'json-schema'  , '~> 2.5.1'
   spec.add_dependency 'uri_template' , '~> 0.7'
 
   spec.add_development_dependency 'bundler', "~> 1.3"


### PR DESCRIPTION
Increase the version of `json-schema` to the latest.

The latest version includes the `JSON::Schema::Reader` which is useful if you want to control how the dependent JSON Schemas are read.  More details here: https://github.com/ruby-json-schema/json-schema#controlling-remote-schema-reading

All the tests pass and I've found no issues.