### PR TITLE
Added support for securitySchemes and securedBy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = FileList['test/raml/**/*_spec.rb']
+end
+
+task default: :spec

--- a/lib/raml.rb
+++ b/lib/raml.rb
@@ -38,6 +38,10 @@ require_relative 'raml/node/resource_type_reference'
 
 require_relative 'raml/node/template'
 
+require_relative 'raml/node/security_scheme'
+require_relative 'raml/node/security_scheme_reference'
+require_relative 'raml/mixin/secured_by'
+
 require_relative 'raml/node/abstract_method'
 require_relative 'raml/node/trait'
 require_relative 'raml/node/method'

--- a/lib/raml/exceptions.rb
+++ b/lib/raml/exceptions.rb
@@ -21,6 +21,7 @@ module Raml
 
   class UnknownTraitReference           < RamlError; end
   class UnknownResourceTypeReference    < RamlError; end
+  class UnknownSecuritySchemeReference  < RamlError; end
   class MergeError                      < RamlError; end
   class UnknownTypeOrTraitParameter     < RamlError; end
   class UnknownTypeOrTraitParamFunction < RamlError; end

--- a/lib/raml/mixin/global.rb
+++ b/lib/raml/mixin/global.rb
@@ -16,5 +16,9 @@ module Raml
   	def schema_declarations
   		@parent.schema_declarations
   	end
+
+    def security_scheme_declarations
+      @parent.security_scheme_declarations
+    end
   end
 end

--- a/lib/raml/mixin/secured_by.rb
+++ b/lib/raml/mixin/secured_by.rb
@@ -1,0 +1,27 @@
+module Raml
+  # @private
+	module SecuredBy
+    def parse_secured_by(data)
+      validate_array :secured_by, data, [String, Hash]
+
+      data.map do |security_scheme|
+        if security_scheme.is_a? Hash
+          raise InvalidProperty, 'is property with map with more than one key' if security_scheme.size > 1
+          raise InvalidProperty, 'is property with map of security_scheme name but params are not a map' unless
+            security_scheme.values[0].is_a? Hash
+          SecuritySchemeReference.new( security_scheme.keys[0], security_scheme.values[0], self )
+        else
+          SecuritySchemeReference.new security_scheme, {}, self
+        end
+      end
+    end
+
+    def _validate_secured_by
+      valid_security_schemes = security_scheme_declarations.keys + ["null"]
+      secured_by.keys.each do |security_scheme_reference|
+        raise UnknownSecuritySchemeReference.new(security_scheme_reference) unless
+          valid_security_schemes.include?(security_scheme_reference)
+      end
+    end
+	end
+end

--- a/lib/raml/node/abstract_method.rb
+++ b/lib/raml/node/abstract_method.rb
@@ -9,6 +9,7 @@ module Raml
     include Validation
     include Bodies
     include Headers
+    include SecuredBy
 
     # @!attribute [rw] protocols
     #   @return [Array<String>, nil] the supported protocols. Nil or an array of up to two string
@@ -28,9 +29,14 @@ module Raml
 
     children_by :query_parameters , :name       , Parameter::QueryParameter
     children_by :responses        , :name       , Response
+    children_by :secured_by       , :name       , SecuritySchemeReference
     
     private
-        
+
+    def validate
+      _validate_secured_by
+    end
+
     def validate_protocols
       if @protocols
         validate_array :protocols, @protocols, String
@@ -51,11 +57,5 @@ module Raml
       validate_hash 'responses', value, [Integer, String], Hash
       value.map { |r_name, r_data| Response.new r_name, r_data, self }
     end
-
-    def parse_secured_by(data)
-      # XXX ignored for now
-      []
-    end
-
   end
 end

--- a/lib/raml/node/abstract_resource.rb
+++ b/lib/raml/node/abstract_resource.rb
@@ -7,6 +7,7 @@ module Raml
     include Merge
     include Parent
     include Validation
+    include SecuredBy
 
     # @!attribute [r] base_uri_parameters
     #   @return [Hash<String, Raml::Parameter::BaseUriParameter>] the base URI parameters, keyed
@@ -28,6 +29,7 @@ module Raml
     children_by :methods            , :name, Raml::Method
     children_by :base_uri_parameters, :name, Parameter::BaseUriParameter, true
     children_by :uri_parameters     , :name, Parameter::UriParameter    , true
+    children_by :secured_by         , :name, SecuritySchemeReference
 
     children_of :traits, [ Raml::Trait, Raml::TraitReference ]
 
@@ -87,7 +89,11 @@ module Raml
     end
 
     private
-    
+
+    def validate
+      _validate_secured_by
+    end
+
     def validate_parent
       raise InvalidParent, "Parent of resource cannot be nil." if @parent.nil?
     end
@@ -152,11 +158,6 @@ module Raml
           resource_type_declarations.include? value
         ResourceTypeReference.new value, self
       end
-    end
-
-    def parse_secured_by(data)
-      # XXX ignored for now
-      []
     end
 
     def instantiate_resource_type

--- a/lib/raml/node/security_scheme.rb
+++ b/lib/raml/node/security_scheme.rb
@@ -1,0 +1,47 @@
+module Raml
+  class SecurityScheme < Template
+  	class Instance < PropertiesNode
+	    inherit_class_attributes
+
+      include Validation
+
+      # @!attribute [rw] description
+      #   @return [String,nil] how the description of the security scheme.
+  		scalar_property :description
+
+      # @!attribute [rw] type
+      #   @return [String,nil] describes the type of the security scheme.
+      scalar_property :type
+
+      # @!attribute [r] described_by
+      #   @return [Hash<String, Raml::Trait>] the trait-like description of the
+      #                                       security scheme.
+
+      # @!attribute [r] settings
+      #   @return [Hash<String, Any] the settings for the security scheme
+
+      non_scalar_property :described_by, :settings
+
+      private
+
+      def parse_described_by(value)
+        validate_hash :described_by, value, String, Hash
+        value.map { |uname, udata| Trait.new uname, udata, self }
+      end
+
+      def parse_settings(value)
+        validate_hash :settings, value, String
+        value
+      end
+  	end
+
+    # Instantiate a new resource type with the given parameters.
+    # @param params [Hash] the parameters to interpolate in the resource type.
+    # @return [Raml::SecurityScheme::Instance] the instantiated resouce type.
+  	def instantiate(params)
+  		instance = Instance.new( *interpolate(params), @parent )
+  		# instance.apply_resource_type # TODO: do we need apply_security_scheme?
+  		instance
+  	end
+  end
+end

--- a/lib/raml/node/security_scheme_reference.rb
+++ b/lib/raml/node/security_scheme_reference.rb
@@ -1,0 +1,5 @@
+module Raml
+	# A reference to a securityScheme defined in the root node.
+  class SecuritySchemeReference < ParametizedReference
+  end
+end

--- a/test/raml/method_spec.rb
+++ b/test/raml/method_spec.rb
@@ -347,6 +347,33 @@ describe Raml::Method do
       }
       it { expect {subject }.to raise_error Raml::InvalidProperty, /Optional properties/ }
     end
+
+    context 'when the securedBy property is defined' do
+      let (:root_data) { {'title' => 'x', 'baseUri' => 'http://foo.com', 'securitySchemes' => ['oauth_2_0' => {'type' => 'OAuth 2.0'}, 'oauth_1_0' => {'type' => 'OAuth 1.0'}] } }
+      context 'when the securedBy property is an array of strings' do
+        let(:data) { { 'securedBy' => ['oauth_2_0', 'oauth_1_0'] } }
+        it { expect{ subject }.to_not raise_error }
+      end
+      context 'when the securedBy property is an array of strings and "null"' do
+        let(:data) { { 'securedBy' => ['oauth_2_0', 'null'] } }
+        it { expect{ subject }.to_not raise_error }
+      end
+      context 'when the securedBy property is an array of hash with single key' do
+        let(:data) { { 'securedBy' => ['oauth_2_0' => {'scopes' => 'ADMINISTRATOR'}] } }
+        it { expect{ subject }.to_not raise_error }
+      end
+      context 'when the securedBy property references a missing security scheme' do
+        let(:data) { { 'securedBy' => ['bar'] } }
+        it { expect{ subject }.to raise_error Raml::UnknownSecuritySchemeReference, /bar/}
+      end
+      context 'when the securedBy property is included it is accessible and' do
+        let(:data) { { 'securedBy' => ['oauth_2_0', 'oauth_1_0'] } }
+        it 'exposes the schema references' do
+          expect( subject.secured_by.values ).to all( be_a Raml::SecuritySchemeReference )
+          subject.secured_by.keys.should contain_exactly('oauth_2_0', 'oauth_1_0')
+        end
+      end
+    end
   end
 
   describe '#merge' do

--- a/test/raml/resource_spec.rb
+++ b/test/raml/resource_spec.rb
@@ -304,6 +304,33 @@ describe Raml::Resource do
       }
       it { expect { subject }.to raise_error Raml::InvalidProperty, /Optional properties/ }
     end
+
+    context 'when the securedBy property is defined' do
+      let (:root_data) { {'title' => 'x', 'baseUri' => 'http://foo.com', 'securitySchemes' => ['oauth_2_0' => {'type' => 'OAuth 2.0'}, 'oauth_1_0' => {'type' => 'OAuth 1.0'}] } }
+      context 'when the securedBy property is an array of strings' do
+        let(:data) { { 'securedBy' => ['oauth_2_0', 'oauth_1_0'] } }
+        it { expect{ subject }.to_not raise_error }
+      end
+      context 'when the securedBy property is an array of strings and "null"' do
+        let(:data) { { 'securedBy' => ['oauth_2_0', 'null'] } }
+        it { expect{ subject }.to_not raise_error }
+      end
+      context 'when the securedBy property is an array of hash with single key' do
+        let(:data) { { 'securedBy' => ['oauth_2_0' => {'scopes' => 'ADMINISTRATOR'}] } }
+        it { expect{ subject }.to_not raise_error }
+      end
+      context 'when the securedBy property references a missing security scheme' do
+        let(:data) { { 'securedBy' => ['bar'] } }
+        it { expect{ subject }.to raise_error Raml::UnknownSecuritySchemeReference, /bar/}
+      end
+      context 'when the securedBy property is included it is accessible and' do
+        let(:data) { { 'securedBy' => ['oauth_2_0', 'oauth_1_0'] } }
+        it 'exposes the schema references' do
+          expect( subject.secured_by.values ).to all( be_a Raml::SecuritySchemeReference )
+          subject.secured_by.keys.should contain_exactly('oauth_2_0', 'oauth_1_0')
+        end
+      end
+    end
   end
 
   describe '#apply_resource_type' do

--- a/test/raml/security_scheme_spec.rb
+++ b/test/raml/security_scheme_spec.rb
@@ -1,0 +1,71 @@
+# encoding: UTF-8
+require_relative 'spec_helper'
+
+describe Raml::SecurityScheme do
+	let(:name) { 'oauth_2_0' }
+  let(:data) {
+    YAML.load(%q(
+      description: |
+          Dropbox supports OAuth 2.0 for authenticating all API requests.
+      type: OAuth 2.0
+      describedBy:
+          headers:
+              Authorization:
+                  description: |
+                      Used to send a valid OAuth 2 access token. Do not use
+                      with the "access_token" query string parameter.
+                  type: string
+          queryParameters:
+              access_token:
+                  description: |
+                      Used to send a valid OAuth 2 access token. Do not use together with
+                      the "Authorization" header
+                  type: string
+          responses:
+              401:
+                  description: |
+                      Bad or expired token. This can happen if the user or Dropbox
+                      revoked or expired an access token. To fix, you should re-
+                      authenticate the user.
+              403:
+                  description: |
+                      Bad OAuth request (wrong consumer key, bad nonce, expired
+                      timestamp...). Unfortunately, re-authenticating the user won't help here.
+      settings:
+          authorizationUri: https://www.dropbox.com/1/oauth2/authorize
+          accessTokenUri: https://api.dropbox.com/1/oauth2/token
+          authorizationGrants: [ code, token ]
+    ))
+  }
+  let(:root) { Raml::Root.new 'title' => 'x', 'baseUri' => 'http://foo.com' }
+
+  subject { Raml::SecurityScheme.new(name, data, root) }
+
+  describe '#new' do
+  	context 'with valid arguments' do
+  	  it { expect { subject }.to_not raise_error }
+  	  it { should be_a Raml::SecurityScheme }
+    end
+  end
+
+  describe '#instantiate' do
+    context 'when the description property is given' do
+  		before { data['description'] = 'Some text' }
+	    it 'stores the description property' do
+        subject.instantiate({}).description.should eq data['description']
+	    end
+	  end
+    context 'when the type property is given' do
+      before { data['type'] = 'Some text' }
+      it 'stores the type property' do
+        subject.instantiate({}).type.should eq data['type']
+      end
+    end
+    context 'with invalid arguments' do
+    	context 'when the securityScheme has nested resources' do
+    		before { data['/foo'] = {} }
+    		it { expect { subject.instantiate({}) }.to raise_error Raml::UnknownProperty, /\/foo/ }
+    	end
+    end
+  end
+end


### PR DESCRIPTION
All features related to securitySchemes and securedBy 
documented in the RAML spec should work.

This adds support to methods and resources for securedBy to my previous PR.