### PR TITLE
add support for null elements in securedBy

### DIFF
--- a/lib/raml/mixin/secured_by.rb
+++ b/lib/raml/mixin/secured_by.rb
@@ -2,7 +2,7 @@ module Raml
   # @private
   module SecuredBy
     def parse_secured_by(data)
-      validate_array :secured_by, data, [String, Hash]
+      validate_array :secured_by, data, [String, Hash, NilClass]
 
       data.map do |security_scheme|
         if security_scheme.is_a? Hash
@@ -20,7 +20,7 @@ module Raml
       valid_security_schemes = security_scheme_declarations.keys + ["null"]
       secured_by.keys.each do |security_scheme_reference|
         raise UnknownSecuritySchemeReference.new(security_scheme_reference) unless
-          valid_security_schemes.include?(security_scheme_reference)
+          security_scheme_reference.nil? || valid_security_schemes.include?(security_scheme_reference)
       end
     end
   end


### PR DESCRIPTION
why: to bring securedBy validation in line with spec for anonymous access

see: https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#applying-security-schemes

"A securedBy node containing null as the array component indicates the method can be called without applying any security scheme."